### PR TITLE
fix (DashboardSidebarListItem): #49 - use Next Link cmpt instead of Mui Link cmpt

### DIFF
--- a/pwa/components/common/Layout.tsx
+++ b/pwa/components/common/Layout.tsx
@@ -1,10 +1,26 @@
-import {ReactNode, useEffect, useState} from 'react';
+import {ReactNode, useState} from 'react';
 import {
   DehydratedState,
   Hydrate,
   QueryClient,
   QueryClientProvider,
 } from 'react-query';
+import theme from '../../styles/theme';
+import CssBaseline from '@mui/material/CssBaseline';
+import {A2HS} from '@components/banner/A2HS';
+import {A2HSIOS} from '@components/banner/A2HSIOS';
+import {ThemeProvider} from '@mui/material/styles';
+import dynamic from 'next/dynamic';
+import {AuthProvider} from '@contexts/AuthContext';
+import {SearchRepairerProvider} from '@contexts/SearchRepairerContext';
+import {UserFormProvider} from '@contexts/UserFormContext';
+
+const Notifications = dynamic(
+  () => import('@components/notifications/Notifications'),
+  {
+    ssr: false,
+  }
+);
 
 const Layout = ({
   children,
@@ -17,7 +33,19 @@ const Layout = ({
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Hydrate state={dehydratedState}>{children}</Hydrate>
+      <Hydrate state={dehydratedState}>
+        <AuthProvider>
+          <ThemeProvider theme={theme}>
+            <CssBaseline />
+            <A2HS />
+            <A2HSIOS />
+            <Notifications />
+            <SearchRepairerProvider>
+              <UserFormProvider>{children}</UserFormProvider>
+            </SearchRepairerProvider>
+          </ThemeProvider>
+        </AuthProvider>
+      </Hydrate>
     </QueryClientProvider>
   );
 };

--- a/pwa/components/dashboard/DashboardSidebarListItem.tsx
+++ b/pwa/components/dashboard/DashboardSidebarListItem.tsx
@@ -6,10 +6,10 @@ import {
   ListItemText,
   ListItem,
   Typography,
-  Link,
   useMediaQuery,
 } from '@mui/material';
 import theme from 'styles/theme';
+import Link from 'next/link';
 
 interface DashboardSidebarListItemProps {
   text: string;
@@ -26,10 +26,6 @@ const DashboardSidebarListItem = ({
 }: DashboardSidebarListItemProps): JSX.Element => {
   const router = useRouter();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-
-  const handleMenuClick = () => {
-    router.push(path);
-  };
 
   return (
     <Link href={path} style={{textDecoration: 'none'}}>

--- a/pwa/components/dashboard/agenda/ModalShowAppointment.tsx
+++ b/pwa/components/dashboard/agenda/ModalShowAppointment.tsx
@@ -35,7 +35,7 @@ import {formatDate, formatDateInSelect} from '@helpers/dateHelper';
 import {getAppointmentStatus} from '@helpers/appointmentStatus';
 import CommentIcon from '@mui/icons-material/Comment';
 import CommentsDisabledIcon from '@mui/icons-material/CommentsDisabled';
-import Divider from '@mui/material/Divider';
+import NextLink from 'next/link';
 
 type ModalShowAppointmentProps = {
   appointment: Appointment;
@@ -184,28 +184,32 @@ const ModalShowAppointment = ({
               </Box>
               <Box>
                 {appointment.discussion && (
-                  <Link
-                    href={`/sradmin/messagerie/${appointment.discussion!.id}`}>
-                    {isMobile ? (
-                      <IconButton
-                        color="secondary"
-                        disabled={!appointment.discussion}
-                        sx={{
-                          borderRadius: '50%',
-                          padding: '8px',
-                        }}>
-                        <EmailIcon />
-                      </IconButton>
-                    ) : (
-                      <Button
-                        size="small"
-                        color="secondary"
-                        disabled={!appointment.discussion}
-                        variant="outlined">
-                        Envoyer un message
-                      </Button>
-                    )}
-                  </Link>
+                  <NextLink
+                    href={`/sradmin/messagerie/${appointment.discussion!.id}`}
+                    legacyBehavior
+                    passHref>
+                    <Link>
+                      {isMobile ? (
+                        <IconButton
+                          color="secondary"
+                          disabled={!appointment.discussion}
+                          sx={{
+                            borderRadius: '50%',
+                            padding: '8px',
+                          }}>
+                          <EmailIcon />
+                        </IconButton>
+                      ) : (
+                        <Button
+                          size="small"
+                          color="secondary"
+                          disabled={!appointment.discussion}
+                          variant="outlined">
+                          Envoyer un message
+                        </Button>
+                      )}
+                    </Link>
+                  </NextLink>
                 )}
               </Box>
             </Box>
@@ -220,27 +224,32 @@ const ModalShowAppointment = ({
                   <Typography>{appointment.bike.name}</Typography>
                 </Box>
                 <Box>
-                  <Link href={`/sradmin/clients/velos/${appointment.bike.id}`}>
-                    {isMobile ? (
-                      <IconButton
-                        color="secondary"
-                        disabled={!appointment.bike}
-                        sx={{
-                          borderRadius: '50%',
-                          padding: '8px',
-                        }}>
-                        <AssignmentIcon />
-                      </IconButton>
-                    ) : (
-                      <Button
-                        size="small"
-                        color="secondary"
-                        disabled={!appointment.bike}
-                        variant="outlined">
-                        Voir le carnet du vélo
-                      </Button>
-                    )}
-                  </Link>
+                  <NextLink
+                    href={`/sradmin/clients/velos/${appointment.bike.id}`}
+                    legacyBehavior
+                    passHref>
+                    <Link>
+                      {isMobile ? (
+                        <IconButton
+                          color="secondary"
+                          disabled={!appointment.bike}
+                          sx={{
+                            borderRadius: '50%',
+                            padding: '8px',
+                          }}>
+                          <AssignmentIcon />
+                        </IconButton>
+                      ) : (
+                        <Button
+                          size="small"
+                          color="secondary"
+                          disabled={!appointment.bike}
+                          variant="outlined">
+                          Voir le carnet du vélo
+                        </Button>
+                      )}
+                    </Link>
+                  </NextLink>
                 </Box>
               </Box>
             )}

--- a/pwa/components/navbar/NavbarDesktop.tsx
+++ b/pwa/components/navbar/NavbarDesktop.tsx
@@ -58,7 +58,7 @@ const NavbarDesktop = ({
     return onClick ? (
       Element
     ) : (
-      <NextLink legacyBehavior href={link}>
+      <NextLink href={link} legacyBehavior passHref>
         {Element}
       </NextLink>
     );
@@ -71,8 +71,10 @@ const NavbarDesktop = ({
       display={{xs: 'none', md: 'flex'}}
       justifyContent="space-between"
       alignItems="center">
-      <NextLink href="/" style={{height: '35px', display: 'block'}}>
-        <Logo inline color="primary" />
+      <NextLink href="/" legacyBehavior passHref>
+        <Link style={{height: '35px', display: 'block'}}>
+          <Logo inline color="primary" />
+        </Link>
       </NextLink>
       <Box display="flex" gap={4} justifyContent="flex" alignItems="center">
         {pages.map(({name, link, disabled}) => {

--- a/pwa/interfaces/NextPageWithLayout.ts
+++ b/pwa/interfaces/NextPageWithLayout.ts
@@ -1,0 +1,6 @@
+import {NextPage} from 'next';
+import {ReactElement, ReactNode} from 'react';
+
+export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};

--- a/pwa/pages/404.tsx
+++ b/pwa/pages/404.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import {

--- a/pwa/pages/_app.tsx
+++ b/pwa/pages/_app.tsx
@@ -2,32 +2,10 @@ import Layout from '@components/common/Layout';
 import type {AppProps} from 'next/app';
 import type {DehydratedState} from 'react-query';
 import Head from 'next/head';
-import {NextPage} from 'next';
-import {ReactElement, ReactNode, Suspense} from 'react';
-import {AuthProvider} from '@contexts/AuthContext';
-import {SearchRepairerProvider} from '@contexts/SearchRepairerContext';
-import {UserFormProvider} from '@contexts/UserFormContext';
-import {ThemeProvider} from '@mui/material/styles';
-import CssBaseline from '@mui/material/CssBaseline';
-import theme from '../styles/theme';
-import {A2HS} from '@components/banner/A2HS';
-import {A2HSIOS} from '@components/banner/A2HSIOS';
-import dynamic from 'next/dynamic';
+import {Suspense} from 'react';
 import '../styles/calendar.css';
-import Script from 'next/script';
 import Analytics from '@components/layout/Analytics';
 import {GoogleOAuthProvider} from '@react-oauth/google';
-
-const Notifications = dynamic(
-  () => import('@components/notifications/Notifications'),
-  {
-    ssr: false,
-  }
-);
-
-export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
-  getLayout?: (page: ReactElement) => ReactNode;
-};
 
 function MyApp({
   Component,
@@ -36,189 +14,170 @@ function MyApp({
   const googleClientId = process.env.GOOGLE_CLIENT_ID;
 
   return (
-    <AuthProvider>
-      <SearchRepairerProvider>
-        <GoogleOAuthProvider
-          clientId={typeof googleClientId === 'string' ? googleClientId : ''}>
-          <UserFormProvider>
-            <>
-              <Head>
-                <meta
-                  name="viewport"
-                  content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, user-scalable=no, viewport-fit=cover"
-                />
-                <meta name="application-name" content="Rustine Libre" />
-                <meta name="apple-mobile-web-app-capable" content="yes" />
-                <meta
-                  name="apple-mobile-web-app-status-bar-style"
-                  content="default"
-                />
-                <meta
-                  name="apple-mobile-web-app-title"
-                  content="Rustine Libre"
-                />
-                <meta name="description" content="Rustine Libre" />
-                <meta name="format-detection" content="telephone=no" />
-                <meta name="mobile-web-app-capable" content="yes" />
-                <meta
-                  name="msapplication-config"
-                  content="/icons/browserconfig.xml"
-                />
-                <meta name="msapplication-TileColor" content="#2B5797" />
-                <meta name="msapplication-tap-highlight" content="no" />
-                <meta name="theme-color" content="#000000" />
-                <meta property="og:type" content="product" />
-                <meta property="og:title" content="Rustine Libre" />
-                <meta
-                  property="og:description"
-                  content="Rustine Libre, la réparation de vos vélos sur Lille Métropole"
-                />
-                <meta property="og:url" content="https://rustinelibre.fr" />
-                <meta property="og:image" content="img/og-image.webp" />
-                <meta property="og:site_name" content="Rustine Libre" />
-                <link rel="manifest" href="/manifest.json"></link>
-                <link
-                  rel="apple-touch-icon"
-                  href="pwa_icons/apple-icon-180.png"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2048-2732.jpg"
-                  media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2732-2048.jpg"
-                  media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1668-2388.jpg"
-                  media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2388-1668.jpg"
-                  media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1536-2048.jpg"
-                  media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2048-1536.jpg"
-                  media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1668-2224.jpg"
-                  media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2224-1668.jpg"
-                  media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1620-2160.jpg"
-                  media="(device-width: 810px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2160-1620.jpg"
-                  media="(device-width: 810px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1290-2796.jpg"
-                  media="(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2796-1290.jpg"
-                  media="(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1179-2556.jpg"
-                  media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2556-1179.jpg"
-                  media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1284-2778.jpg"
-                  media="(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2778-1284.jpg"
-                  media="(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1170-2532.jpg"
-                  media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2532-1170.jpg"
-                  media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1125-2436.jpg"
-                  media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2436-1125.jpg"
-                  media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1242-2688.jpg"
-                  media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2688-1242.jpg"
-                  media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-828-1792.jpg"
-                  media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1792-828.jpg"
-                  media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1242-2208.jpg"
-                  media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-2208-1242.jpg"
-                  media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-750-1334.jpg"
-                  media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1334-750.jpg"
-                  media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-640-1136.jpg"
-                  media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
-                <link
-                  rel="apple-touch-startup-image"
-                  href="pwa_icons/apple-splash-1136-640.jpg"
-                  media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
-              </Head>
-              <Suspense>
-                <Analytics />
-              </Suspense>
-              <ThemeProvider theme={theme}>
-                <CssBaseline>
-                  <A2HS></A2HS>
-                  <A2HSIOS></A2HSIOS>
-                  <Notifications></Notifications>
-                  <Layout dehydratedState={pageProps.dehydratedState}>
-                    <Component {...pageProps} />
-                  </Layout>
-                </CssBaseline>
-              </ThemeProvider>
-            </>
-          </UserFormProvider>
-        </GoogleOAuthProvider>
-      </SearchRepairerProvider>
-    </AuthProvider>
+    <>
+      <Head>
+        <meta
+          name="viewport"
+          content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, user-scalable=no, viewport-fit=cover"
+        />
+        <meta name="application-name" content="Rustine Libre" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+        <meta name="apple-mobile-web-app-title" content="Rustine Libre" />
+        <meta name="description" content="Rustine Libre" />
+        <meta name="format-detection" content="telephone=no" />
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="msapplication-config" content="/icons/browserconfig.xml" />
+        <meta name="msapplication-TileColor" content="#2B5797" />
+        <meta name="msapplication-tap-highlight" content="no" />
+        <meta name="theme-color" content="#000000" />
+        <meta property="og:type" content="product" />
+        <meta property="og:title" content="Rustine Libre" />
+        <meta
+          property="og:description"
+          content="Rustine Libre, la réparation de vos vélos sur Lille Métropole"
+        />
+        <meta property="og:url" content="https://rustinelibre.fr" />
+        <meta property="og:image" content="img/og-image.webp" />
+        <meta property="og:site_name" content="Rustine Libre" />
+        <link
+          rel="manifest"
+          href="/manifest.json"
+          crossOrigin="use-credentials"></link>
+        <link
+          rel="apple-touch-icon"
+          href="/pwa_icons/apple-icon-180.png"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2048-2732.jpg"
+          media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2732-2048.jpg"
+          media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1668-2388.jpg"
+          media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2388-1668.jpg"
+          media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1536-2048.jpg"
+          media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2048-1536.jpg"
+          media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1668-2224.jpg"
+          media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2224-1668.jpg"
+          media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1620-2160.jpg"
+          media="(device-width: 810px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2160-1620.jpg"
+          media="(device-width: 810px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1290-2796.jpg"
+          media="(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2796-1290.jpg"
+          media="(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1179-2556.jpg"
+          media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2556-1179.jpg"
+          media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1284-2778.jpg"
+          media="(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2778-1284.jpg"
+          media="(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1170-2532.jpg"
+          media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2532-1170.jpg"
+          media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1125-2436.jpg"
+          media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2436-1125.jpg"
+          media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1242-2688.jpg"
+          media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2688-1242.jpg"
+          media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-828-1792.jpg"
+          media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1792-828.jpg"
+          media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1242-2208.jpg"
+          media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-2208-1242.jpg"
+          media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-750-1334.jpg"
+          media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1334-750.jpg"
+          media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-640-1136.jpg"
+          media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"></link>
+        <link
+          rel="apple-touch-startup-image"
+          href="/pwa_icons/apple-splash-1136-640.jpg"
+          media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"></link>
+      </Head>
+      <GoogleOAuthProvider
+        clientId={typeof googleClientId === 'string' ? googleClientId : ''}>
+        <Suspense>
+          <Analytics />
+        </Suspense>
+        <Layout dehydratedState={pageProps.dehydratedState}>
+          <Component {...pageProps} />
+        </Layout>
+      </GoogleOAuthProvider>
+    </>
   );
 }
 

--- a/pwa/pages/admin/contact/[id].tsx
+++ b/pwa/pages/admin/contact/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useEffect} from 'react';
 import Head from 'next/head';
 import Box from '@mui/material/Box';

--- a/pwa/pages/admin/modifier-mot-de-passe.tsx
+++ b/pwa/pages/admin/modifier-mot-de-passe.tsx
@@ -1,4 +1,3 @@
-import {NextPageWithLayout} from '../_app';
 import ChangePassword from '@components/profile/ChangePassword';
 import AdminLayout from '@components/admin/AdminLayout';
 import Head from 'next/head';

--- a/pwa/pages/admin/parametres/interventions/ajouter.tsx
+++ b/pwa/pages/admin/parametres/interventions/ajouter.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import Box from '@mui/material/Box';

--- a/pwa/pages/admin/parametres/interventions/edit/[id].tsx
+++ b/pwa/pages/admin/parametres/interventions/edit/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useEffect} from 'react';
 import Head from 'next/head';
 import Box from '@mui/material/Box';

--- a/pwa/pages/admin/parametres/type-de-reparateur/ajouter.tsx
+++ b/pwa/pages/admin/parametres/type-de-reparateur/ajouter.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import Box from '@mui/material/Box';

--- a/pwa/pages/admin/parametres/type-de-reparateur/edit/[id].tsx
+++ b/pwa/pages/admin/parametres/type-de-reparateur/edit/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useEffect} from 'react';
 import Head from 'next/head';
 import Box from '@mui/material/Box';

--- a/pwa/pages/admin/parametres/type-de-velo/ajouter.tsx
+++ b/pwa/pages/admin/parametres/type-de-velo/ajouter.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import Box from '@mui/material/Box';

--- a/pwa/pages/admin/parametres/type-de-velo/edit/[id].tsx
+++ b/pwa/pages/admin/parametres/type-de-velo/edit/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useEffect} from 'react';
 import Head from 'next/head';
 import Box from '@mui/material/Box';

--- a/pwa/pages/admin/profil.tsx
+++ b/pwa/pages/admin/profil.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useContext} from 'react';
 import Head from 'next/head';
 import {

--- a/pwa/pages/admin/reparateurs/edit/[id].tsx
+++ b/pwa/pages/admin/reparateurs/edit/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useEffect} from 'react';
 import Head from 'next/head';
 import Box from '@mui/material/Box';

--- a/pwa/pages/admin/utilisateurs/edit/[id].tsx
+++ b/pwa/pages/admin/utilisateurs/edit/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useEffect, useContext} from 'react';
 import Head from 'next/head';
 import Box from '@mui/material/Box';

--- a/pwa/pages/carnet/creer-mon-carnet.tsx
+++ b/pwa/pages/carnet/creer-mon-carnet.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import WebsiteLayout from '@components/layout/WebsiteLayout';

--- a/pwa/pages/cgu.tsx
+++ b/pwa/pages/cgu.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import {Container, Typography, Paper, Avatar, Box} from '@mui/material';

--- a/pwa/pages/contact.tsx
+++ b/pwa/pages/contact.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {ChangeEvent, useState} from 'react';
 import Head from 'next/head';
 import {contactResource} from '@resources/ContactResource';

--- a/pwa/pages/faq.tsx
+++ b/pwa/pages/faq.tsx
@@ -1,7 +1,7 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
-import {Container, Typography, Paper, Avatar, Box} from '@mui/material';
+import {Container, Typography, Box} from '@mui/material';
 import WebsiteLayout from '@components/layout/WebsiteLayout';
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';

--- a/pwa/pages/inscription.tsx
+++ b/pwa/pages/inscription.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useContext, ChangeEvent, useEffect} from 'react';
 import Head from 'next/head';
 import {useRouter} from 'next/router';

--- a/pwa/pages/liste-des-reparateurs.tsx
+++ b/pwa/pages/liste-des-reparateurs.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useEffect, useContext} from 'react';
 import Head from 'next/head';
 import WebsiteLayout from '@components/layout/WebsiteLayout';

--- a/pwa/pages/login.tsx
+++ b/pwa/pages/login.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, ChangeEvent, useEffect} from 'react';
 import Head from 'next/head';
 import {useRouter} from 'next/router';

--- a/pwa/pages/login.tsx
+++ b/pwa/pages/login.tsx
@@ -17,6 +17,7 @@ import {
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import WebsiteLayout from '@components/layout/WebsiteLayout';
 import {isAdmin, isBoss, isEmployee} from '@helpers/rolesHelpers';
+import NextLink from 'next/link';
 
 const Login: NextPageWithLayout = ({}) => {
   const [email, setEmail] = useState<string>('');
@@ -152,15 +153,19 @@ const Login: NextPageWithLayout = ({}) => {
                       display="flex"
                       justifyContent="space-between"
                       width="100%">
-                      <Link
-                        rel="canonical"
+                      <NextLink
                         href="/mot-de-passe-oublie"
-                        variant="body2">
-                        Mot de passe oublié ?
-                      </Link>
-                      <Link rel="canonical" href="/inscription" variant="body2">
-                        S’inscrire
-                      </Link>
+                        legacyBehavior
+                        passHref>
+                        <Link rel="canonical" variant="body2">
+                          Mot de passe oublié ?
+                        </Link>
+                      </NextLink>
+                      <NextLink href="/inscription" legacyBehavior passHref>
+                        <Link rel="canonical" variant="body2">
+                          S’inscrire
+                        </Link>
+                      </NextLink>
                     </Box>
                   </Box>
                 </Box>

--- a/pwa/pages/mentions-legales.tsx
+++ b/pwa/pages/mentions-legales.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import {

--- a/pwa/pages/messagerie/[id].tsx
+++ b/pwa/pages/messagerie/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import WebsiteLayout from '@components/layout/WebsiteLayout';

--- a/pwa/pages/messagerie/index.tsx
+++ b/pwa/pages/messagerie/index.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import WebsiteLayout from '@components/layout/WebsiteLayout';

--- a/pwa/pages/mon-compte.tsx
+++ b/pwa/pages/mon-compte.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import {Typography, Box, Container} from '@mui/material';

--- a/pwa/pages/mot-de-passe-oublie.tsx
+++ b/pwa/pages/mot-de-passe-oublie.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {ChangeEvent, useState} from 'react';
 import Head from 'next/head';
 import {userResource} from '@resources/userResource';

--- a/pwa/pages/notre-charte.tsx
+++ b/pwa/pages/notre-charte.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import {Container, Typography, Box, List, ListItem} from '@mui/material';

--- a/pwa/pages/notre-collectif.tsx
+++ b/pwa/pages/notre-collectif.tsx
@@ -1,9 +1,9 @@
-import {NextPageWithLayout} from 'pages/_app';
 import React from 'react';
 import Head from 'next/head';
 import {Container, Typography, Box, List, ListItem, Link} from '@mui/material';
 import WebsiteLayout from '@components/layout/WebsiteLayout';
 import NextLink from 'next/link';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 
 const OurCollective: NextPageWithLayout = () => {
   return (

--- a/pwa/pages/politique-de-confidentialite.tsx
+++ b/pwa/pages/politique-de-confidentialite.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import {Container, Typography, Box} from '@mui/material';

--- a/pwa/pages/reinitialiser-mot-de-passe.tsx
+++ b/pwa/pages/reinitialiser-mot-de-passe.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {ChangeEvent, useState} from 'react';
 import {GetServerSideProps, InferGetServerSidePropsType} from 'next';
 import Head from 'next/head';

--- a/pwa/pages/rendez-vous/[id]/auto-diagnostic.tsx
+++ b/pwa/pages/rendez-vous/[id]/auto-diagnostic.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import WebsiteLayout from '@components/layout/WebsiteLayout';

--- a/pwa/pages/rendez-vous/mes-rendez-vous.tsx
+++ b/pwa/pages/rendez-vous/mes-rendez-vous.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useMemo, useState} from 'react';
 import Head from 'next/head';
 import {Container, Typography, Paper, Button, Box} from '@mui/material';

--- a/pwa/pages/rendez-vous/recapitulatif/[id].tsx
+++ b/pwa/pages/rendez-vous/recapitulatif/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useEffect, useState} from 'react';
 import Head from 'next/head';
 import {useRouter} from 'next/router';

--- a/pwa/pages/reparateur/[id].tsx
+++ b/pwa/pages/reparateur/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useEffect, useState} from 'react';
 import {GetStaticProps} from 'next';
 import Head from 'next/head';

--- a/pwa/pages/reparateur/[id]/creneaux.tsx
+++ b/pwa/pages/reparateur/[id]/creneaux.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useCallback, useEffect, useState} from 'react';
 import Head from 'next/head';
 import {useRouter} from 'next/router';

--- a/pwa/pages/reparateur/chercher-un-reparateur.tsx
+++ b/pwa/pages/reparateur/chercher-un-reparateur.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import {ENTRYPOINT} from '@config/entrypoint';
 import React, {
   useState,

--- a/pwa/pages/reparateur/inscription.tsx
+++ b/pwa/pages/reparateur/inscription.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import {ENTRYPOINT} from '@config/entrypoint';
 import React, {
   useState,

--- a/pwa/pages/reparateur/rejoindre-le-collectif.tsx
+++ b/pwa/pages/reparateur/rejoindre-le-collectif.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import WebsiteLayout from '@components/layout/WebsiteLayout';

--- a/pwa/pages/sradmin/agenda/index.tsx
+++ b/pwa/pages/sradmin/agenda/index.tsx
@@ -4,7 +4,7 @@ import {useAccount} from '@contexts/AuthContext';
 import {Box} from '@mui/material';
 import DashboardLayout from '@components/dashboard/DashboardLayout';
 import {Repairer} from '@interfaces/Repairer';
-import {NextPageWithLayout} from '../../_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import AgendaCalendar from '@components/dashboard/agenda/AgendaCalendar';
 
 const Agenda: NextPageWithLayout = () => {

--- a/pwa/pages/sradmin/agenda/parametres.tsx
+++ b/pwa/pages/sradmin/agenda/parametres.tsx
@@ -4,7 +4,7 @@ import {useAccount} from '@contexts/AuthContext';
 import {Box, Tabs, Tab} from '@mui/material';
 import DashboardLayout from '@components/dashboard/DashboardLayout';
 import {Repairer} from '@interfaces/Repairer';
-import {NextPageWithLayout} from '../../_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import OpeningHours from '@components/dashboard/agenda/OpeningHours';
 import ExceptionalClosure from '@components/dashboard/agenda/ExceptionalClosure';
 

--- a/pwa/pages/sradmin/clients/[id].tsx
+++ b/pwa/pages/sradmin/clients/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useEffect} from 'react';
 import Head from 'next/head';
 import DashboardLayout from '@components/dashboard/DashboardLayout';

--- a/pwa/pages/sradmin/clients/velos/[id].tsx
+++ b/pwa/pages/sradmin/clients/velos/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useEffect} from 'react';
 import {useRouter} from 'next/router';
 import Head from 'next/head';

--- a/pwa/pages/sradmin/employes/ajouter.tsx
+++ b/pwa/pages/sradmin/employes/ajouter.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React from 'react';
 import Head from 'next/head';
 import DashboardLayout from '@components/dashboard/DashboardLayout';

--- a/pwa/pages/sradmin/employes/edit/[id].tsx
+++ b/pwa/pages/sradmin/employes/edit/[id].tsx
@@ -1,5 +1,5 @@
-import {NextPageWithLayout} from 'pages/_app';
-import React, {useState, useEffect, useContext} from 'react';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
+import React, {useState, useEffect} from 'react';
 import Head from 'next/head';
 import DashboardLayout from '@components/dashboard/DashboardLayout';
 import Box from '@mui/material/Box';

--- a/pwa/pages/sradmin/index.tsx
+++ b/pwa/pages/sradmin/index.tsx
@@ -18,7 +18,7 @@ const Dashboard = () => {
     if (user && user.repairerEmployee) {
       setRepairer(user.repairerEmployee.repairer);
     }
-  }, [user]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [user]);
 
   return (
     <>

--- a/pwa/pages/sradmin/informations.tsx
+++ b/pwa/pages/sradmin/informations.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from '../_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import Head from 'next/head';
 import {useAccount} from '@contexts/AuthContext';
 import DashboardLayout from '@components/dashboard/DashboardLayout';

--- a/pwa/pages/sradmin/messagerie/[id].tsx
+++ b/pwa/pages/sradmin/messagerie/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useEffect} from 'react';
 import Head from 'next/head';
 import {useRouter} from 'next/router';

--- a/pwa/pages/velos/[id].tsx
+++ b/pwa/pages/velos/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useState, useEffect} from 'react';
 import {NextRouter, useRouter} from 'next/router';
 import Head from 'next/head';

--- a/pwa/pages/velos/mes-velos.tsx
+++ b/pwa/pages/velos/mes-velos.tsx
@@ -1,4 +1,4 @@
-import {NextPageWithLayout} from 'pages/_app';
+import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
 import React, {useEffect, useState} from 'react';
 import Head from 'next/head';
 import {useRouter} from 'next/router';


### PR DESCRIPTION
# Description

In preprod, navigate on the admin part, google chrome asks user to authenticate every time when clicking on the sidebar links.

1 - short refacto in _app.tsx and Layout.tsx
2 - Link component from Mui was used instead of Next Link component, which caused a refresh on the application clicking on the links. Using the correct component, which helps mitigate chrome's basic authentication request,

This does not solve the whole problem because sometimes the problem randomly reoccurs on any link that use the good component..

# Changes

| Q             | A        
|---------------| ---------
| Issue         | #49 
| Type          | <ul><li>- [ ] Feat</li><li>- [ ] Hotfix</li><li>- [ ] Doc</li><li>- [x] Refacto</li><li> [x] Fix</ul>
| Break changes |  No





