### PR TITLE
fix(pwa): #74 - use only NEXT_PUBLIC_ENTRYPOINT value for ENTRYPOINT

### DIFF
--- a/pwa/config/entrypoint.ts
+++ b/pwa/config/entrypoint.ts
@@ -1,4 +1,1 @@
-export const ENTRYPOINT =
-  typeof window === 'undefined'
-    ? process.env.NEXT_PUBLIC_ENTRYPOINT
-    : window.origin;
+export const ENTRYPOINT = process.env.NEXT_PUBLIC_ENTRYPOINT;

--- a/pwa/pages/liste-des-reparateurs.tsx
+++ b/pwa/pages/liste-des-reparateurs.tsx
@@ -9,8 +9,6 @@ import Grid2 from '@mui/material/Unstable_Grid2';
 import {RepairerCard} from '@components/repairers/RepairerCard';
 import {SearchRepairerContext} from '@contexts/SearchRepairerContext';
 import router from 'next/router';
-import {GetServerSideProps, InferGetServerSidePropsType} from 'next';
-import {ENTRYPOINT} from '@config/entrypoint';
 import FullLoading from '@components/common/FullLoading';
 
 const RepairersList: NextPageWithLayout = ({}) => {

--- a/pwa/pages/reparateur/[id].tsx
+++ b/pwa/pages/reparateur/[id].tsx
@@ -3,7 +3,6 @@ import React, {useEffect, useState} from 'react';
 import {GetStaticProps} from 'next';
 import Head from 'next/head';
 import {useRouter} from 'next/router';
-import {ENTRYPOINT} from '@config/entrypoint';
 import {repairerResource} from '@resources/repairerResource';
 import WebsiteLayout from '@components/layout/WebsiteLayout';
 import RepairerPresentation from '@components/repairers/RepairerPresentation';
@@ -59,13 +58,6 @@ const RepairerPage: NextPageWithLayout<RepairerPageProps> = ({
 };
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
-  if (!ENTRYPOINT) {
-    return {
-      notFound: true,
-      revalidate: 0,
-    };
-  }
-
   if (!params) {
     return {
       notFound: true,

--- a/pwa/pages/reparateur/chercher-un-reparateur.tsx
+++ b/pwa/pages/reparateur/chercher-un-reparateur.tsx
@@ -1,5 +1,4 @@
 import {NextPageWithLayout} from '@interfaces/NextPageWithLayout';
-import {ENTRYPOINT} from '@config/entrypoint';
 import React, {
   useState,
   useEffect,
@@ -546,12 +545,6 @@ const SearchRepairer: NextPageWithLayout<SearchRepairerProps> = ({
 };
 
 export const getStaticProps: GetStaticProps = async () => {
-  if (!ENTRYPOINT) {
-    return {
-      props: {},
-    };
-  }
-
   const bikeTypesCollection = await bikeTypeResource.getAll(false);
   const bikeTypesFetched = bikeTypesCollection['hydra:member'];
 


### PR DESCRIPTION
# Description

Only use the value of the NEXT_PUBLIC_ENTRYPOINT env variable for the ENTRYPOINT variable and then remove the checks on NEXT_PUBLIC_ENTRYPOINT in the getStaticProps


# Changes

| Q             | A        
|---------------| ---------
| Issue         | #74 
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Fix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes | No
