### PR TITLE
fix: reset map informations when the city is erased

### DIFF
--- a/pwa/components/rendez-vous/PinMap.tsx
+++ b/pwa/components/rendez-vous/PinMap.tsx
@@ -77,6 +77,9 @@ const PinMap = ({
   useEffect(() => {
     if (cityInput === '' || cityInput.length < 2) {
       setCitiesList([]);
+      setStreetSelected(null);
+      setLatitudeCalculate(null);
+      setLongitudeCalculate(null);
     } else fetchCitiesResult(cityInput);
   }, [setCitiesList, fetchCitiesResult, cityInput]);
 


### PR DESCRIPTION
# Description

reset map informations when the city is erased


# Changes

| Q             | A        
|---------------| ---------
| Issue         | #99 ..
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes | No





