### PR TITLE
fix(ingress): Force HTML content type for Bingbot on root path

### DIFF
--- a/helm/chart/templates/ingress.yaml
+++ b/helm/chart/templates/ingress.yaml
@@ -20,6 +20,12 @@ metadata:
     {{- include "rustinelibre.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+        if ($http_user_agent ~* "bingbot") {
+          if ($request_uri = "/") {
+            proxy_set_header Accept "text/html";
+          }
+        }
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
# Description


Bingbot and DuckDuckGo were indexing the JSON-LD API response instead of the main HTML content on the root URL.

This was caused by the server's content negotiation logic defaulting to 'application/ld+json' for crawlers sending a generic 'Accept: \*/\*' header.

This PR adds a rule to the Ingress controller to intercept requests from Bingbot to the homepage and explicitly set the 'Accept' header to 'text/html', forcing the correct content to be served for SEO indexing.


# Changes

| Q             | A        
|---------------| ---------
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |   No





