### PR TITLE
Fix mercure requiring go >= 1.25.0

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -101,7 +101,7 @@ RUN set -eux; \
 RUN rm -f .env.local.php
 
 # Build Caddy with the Mercure and Vulcain modules
-FROM caddy:2.9.1-builder-alpine AS app_caddy_builder
+FROM caddy:2.10.2-builder-alpine AS app_caddy_builder
 
 RUN xcaddy build \
 	--with github.com/dunglas/mercure/caddy \


### PR DESCRIPTION
# Description

Update caddy to a version embedding go >= 1.25.0, required by mercure






