### PR TITLE
Gate Dependabot auto-merge behind a repo variable

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,4 +1,14 @@
-name: Dependabot auto-merge
+# Auto-merge of Dependabot PRs, gated by the DEPENDABOT_AUTOMERGE repo variable.
+# The level lives only in the variable, so changing it requires no commit:
+#
+#   absent  no automatic merge
+#   patch   production patches and development dependencies
+#   minor   patches, minors and development dependencies
+#
+# Any other value, and a missing variable, merge nothing. Major bumps never
+# auto-merge whatever the level: they get the needs-human label instead.
+name: Auto-merge Dependabot PRs
+
 on: pull_request
 
 permissions:
@@ -6,18 +16,33 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
+  auto-merge:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'RustineLibre/RustineLibre'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository && github.repository == 'RustineLibre/RustineLibre' && !github.event.pull_request.draft
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+      - uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        id: meta
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-merge for Dependabot PRs
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: |
+          contains(fromJSON('["patch","minor"]'), vars.DEPENDABOT_AUTOMERGE) &&
+          steps.meta.outputs.update-type != 'version-update:semver-major' &&
+          (steps.meta.outputs.dependency-type == 'direct:development' ||
+           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+           (vars.DEPENDABOT_AUTOMERGE == 'minor' &&
+            steps.meta.outputs.update-type == 'version-update:semver-minor'))
         run: gh pr merge --auto --merge "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Not gated on the switch: labelling has no side effect and feeds the
+      # human queue right away, without waiting for merges to be enabled.
+      - name: Flag major
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        run: gh pr edit "$PR_URL" --add-label "needs-human"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This workflow never merges anything itself. It turns on GitHub's native auto-merge for a Dependabot PR, and GitHub performs the merge once the required checks pass. Until now the only filter was `semver-patch`, and the level was hard-coded: suspending auto-merge meant editing the workflow and pushing to `main`. That push is itself a trigger — Dependabot rebases its open PRs when the base branch moves, and those rebases can cascade into merges. So the switch has to live outside the code.

The allowed level now comes from the `DEPENDABOT_AUTOMERGE` repository variable, read at run time:

```
absent  no automatic merge
patch   production patches and development dependencies
minor   patches, minors and development dependencies
```

Any other value, and a missing variable, merge nothing. Major bumps never auto-merge at either level; they get the `needs-human` label instead and land in a human queue.

The variable does not exist on this repository and is not created here, so **auto-merge is off after this PR, patches included**. That is a real change in behaviour rather than a no-op: patch bumps currently do merge on their own — 5b7975f and #256 both landed that way, merged by `github-actions[bot]`.

Two guards are added to the job condition alongside the existing author check: the event actor must also be `dependabot[bot]`, and the head branch must belong to this repository. The author check alone is true for the whole life of a PR, so it would keep arming auto-merge on a branch a human had just pushed to.

## Prerequisite

- [x] Create the `needs-human` label. It does not exist among this repository's labels.

Part of coopTilleuls/tma#25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
